### PR TITLE
remove unnecessary packages from tarball profile

### DIFF
--- a/profiles/tarball/packages.txt
+++ b/profiles/tarball/packages.txt
@@ -1,6 +1,4 @@
 base
-linux
-fastfetch
 vim
 sudo
 dinit


### PR DESCRIPTION
Remove 'linux' and 'fastfetch' from tarball profile