### PR TITLE
Add commonly used firmware for liveimage-desktop profile

### DIFF
--- a/profiles/liveimage-desktop/packages.txt
+++ b/profiles/liveimage-desktop/packages.txt
@@ -11,6 +11,8 @@ dinit
 linux-firmware
 linux-firmware-amdgpu
 linux-firmware-iwlwifi
+linux-firmware-mediatek
+linux-firmware-qcom
 hyprland
 foot
 waybar


### PR DESCRIPTION
Add firmware packages (linux-firmware-{mediatek,qcom}) for liveimage-desktop profile