### PR TITLE
Add liveimage-standard profile

### DIFF
--- a/profiles/liveimage-standard/config.sh
+++ b/profiles/liveimage-standard/config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+enable_service connman
+enable_service greetd
+
+cat <<EOF >>/etc/greetd/config.toml
+[initial_session]
+command = "bash -c 'cat /etc/motd && bash'"
+user = "ewe"
+EOF

--- a/profiles/liveimage-standard/packages.txt
+++ b/profiles/liveimage-standard/packages.txt
@@ -1,0 +1,17 @@
+base
+greetd
+seatd
+tinyramfs
+linux
+limine
+fastfetch
+vim
+sudo
+dinit
+linux-firmware
+linux-firmware-amdgpu
+linux-firmware-iwlwifi
+linux-firmware-mediatek
+linux-firmware-qcom
+connman
+wpa_supplicant


### PR DESCRIPTION
This profile provides better hardware compatibility than minimal profile, serving as the best option for system maintaining/installation.